### PR TITLE
Fixed Infinite Loop on Ctrl + D

### DIFF
--- a/StreamShell.cpp
+++ b/StreamShell.cpp
@@ -171,7 +171,14 @@ int main(int argc, char *argv[])
         // Display prompt and wait for input
         std::cout << "StreamShell$ ";
         std::string rawMultiShell;
-        getline(std::cin, rawMultiShell);
+
+        // Handle End Of File
+        if(!getline(std::cin, rawMultiShell))
+        {
+            std::cout<<"\nExiting shell\n";
+            break;
+        }
+
         // Replace environment variables in the user input
         rawMultiShell = Parser::replaceEnvironmentVariables(rawMultiShell);
 


### PR DESCRIPTION
The getline function reads until it encounters an end-of-file or newline character. If Ctrl + D is used to signal end-of-file, and the shell doesn't handle it correctly, it might lead to unexpected behavior.